### PR TITLE
Adjusted routes for SEO

### DIFF
--- a/imports/api/blog-posts.js
+++ b/imports/api/blog-posts.js
@@ -36,8 +36,8 @@ if (Meteor.isServer) {
 	Meteor.publish('BlogPosts_single', function(id) {
 		return BlogPosts.find({_id: id});
 	});
-	Meteor.publish('BlogPosts_singleTitle', function(tag_name, slug) {
-		return BlogPosts.find({tag: tag_name, slug: slug});
+	Meteor.publish('BlogPosts_singleTitle', function(postTitleSlug) {
+		return BlogPosts.find({slug: postTitleSlug});
 	});
 
 	Meteor.publish('BlogPosts_all', function() {

--- a/imports/startup/router.js
+++ b/imports/startup/router.js
@@ -42,31 +42,24 @@ FlowRouter.route('/blog', {
 		DocHead.setTitle('TheKove -- Blog');
 	}
 });
-/* a routing experiement */
-FlowRouter.route('/blog/cpat', {
+FlowRouter.route('/blog/tag/cpat', {
 	action: function(params) {
 		BlazeLayout.render('mainLayout', {content: 'cpat'});
 		DocHead.setTitle('TheKove -- CPAT');
 	}
 });
-FlowRouter.route('/blog/:_slug', {
+FlowRouter.route('/blog/tag/:_slug', {
 	action: function(params) {
 		BlazeLayout.render('mainLayout', {content: 'section'});
 		DocHead.setTitle('TheKove -- ' + params._slug);
 	}
 });
-FlowRouter.route('/blog/:_name/:_slug', {
+FlowRouter.route('/blog/:_postTitle', {
 	action: function(params) {
 		BlazeLayout.render('mainLayout', {content: 'post'});
+		DocHead.setTitle('TheKove -- ' + params._postTitle);
 	}
 });
-/****/
-/*FlowRouter.route('/blog/:_id', {   // already broken
-	action: function(params) {
-		BlazeLayout.render('mainLayout', {content: 'post'});
-	}
-});*/
-
 
 FlowRouter.route('/documents', {
 	action: function(params) {

--- a/imports/ui/documents.html
+++ b/imports/ui/documents.html
@@ -3,10 +3,11 @@
 {{#if Template.subscriptionsReady}}
 	{{> documents_newDocModal}}
 
-	<h4 class="page-header">Documents</h4>
+	
 	
   <div class="row">
     <div class="col-md-6">
+      <h4 class="page-header">Tags</h4>
       <div class="list-group docs-list">
       {{#each tags}}
         <ul class="list-group-item docs-list__doc">
@@ -22,6 +23,7 @@
       </div>
     </div>
     <div class="col-md-6">
+      <h4 class="page-header">Documents</h4>
       <a href="#" class="btn btn-success add-new-document" data-toggle="modal" data-target="#new-document-modal">Start a New Document</a>
       <div class="list-group docs-list">
       {{#each docs}}

--- a/imports/ui/landing.html
+++ b/imports/ui/landing.html
@@ -7,7 +7,7 @@
 				{{#each docs}}
 					<div class="blog-post">
 						<div class="blog-post-title">
-							<a href="{{pathFor '/blog/:_name/:_slug' _name=tag _slug=slug}}">{{title}}</a>
+							<a href="{{pathFor '/blog/:_postTitle' _postTitle=slug}}">{{title}}</a>
 						</div>
 						<div class="blog-post-date"><i>{{formattedCreateDate createdAt}}</i></div>
 {{#markdown}}
@@ -21,7 +21,7 @@
 			<div class="site-toc">
 				<ul>
 					{{#each tags}}
-					<li><a href="{{pathFor '/blog/:_slug' _slug=slug}}">{{name}}</a></li>
+					<li><a href="{{pathFor '/blog/tag/:_slug' _slug=slug}}">{{name}}</a></li>
 					{{/each}}
 				</ul>
 			</div>

--- a/imports/ui/post.js
+++ b/imports/ui/post.js
@@ -7,18 +7,16 @@ import './post.html';
 Template.post.helpers({
 	doc() {
 		let post = Template.instance().myPosts();
-		DocHead.setTitle('TheKove -- ' + post.title);
 		return post;
 	}
 });
 
 Template.post.onCreated(function() {
 	var instance = this;
-	var tagName = FlowRouter.getParam("_name");
-	var postTitle = FlowRouter.getParam("_slug");
+	var postTitle = FlowRouter.getParam("_postTitle");
 
 	instance.autorun(function() {
-		var subscription = instance.subscribe('BlogPosts_singleTitle', tagName, postTitle);
+		var subscription = instance.subscribe('BlogPosts_singleTitle', postTitle);
 		if (subscription.ready()) { // use instance.subscriptionsReady() for multiple subscriptions
 			console.log('BlogPosts_singleTitle is ready');
 		}


### PR DESCRIPTION
Routes for posts are now "/blog/<post-title-here>". To avoid the regex consumption between '/blog/_tag' and '/blog/_postTitle' the routes for tagged sections follow '/blog/tag/_tag'. Pub/subs and links were updated accordingly.